### PR TITLE
Add disable GA tracking for specific events

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ myTracker.disableGA({
 And reset the action after the PV / events:
 
 ```js
-myTracker.disableGA(false);
+myTracker.resetGAFlags();
 ```
 
 However, if all GA profiles are disabled, please set `GA: false` in event or PV.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,26 @@ myTracker.fire(
 myTracker.setUserId('new_user_id');
 ```
 
+#### Disable specific GA profile in PV / events
+
+When we want to disable specific profile in GA, for example, disable `UA-123456-2` and `UA-123456-4`, the following action should be done before PV / events: 
+
+```js
+myTracker.disableGA({
+  'UA-123456-2': true,
+  'UA-123456-3': false,
+  'UA-123456-4': true,
+});
+```
+
+And reset the action after the PV / events:
+
+```js
+myTracker.disableGA(false);
+```
+
+However, if all GA profiles are disabled, please set `GA: false` in event or PV.
+
 #### Test the page by creating local http server
 
 Use the library `http.server` in *Python 3* to create local http server. The GA event will not fire when the webpage protocol is `file://`

--- a/src/trackerClient.js
+++ b/src/trackerClient.js
@@ -175,19 +175,30 @@ class trackerClient{
   }
 
   disableGA(ga_list = null){
-    if(ga_list === null || ga_list === false || ga_list === true){
-      var temp_stage = ga_list?ga_list:false;
+    if(ga_list === true){
       if(Array.isArray(this.GAId)){
         this.GAId.map(function(gid){
-          window['ga-disable-'+gid] = temp_stage;
+          window['ga-disable-'+gid] = true;
         }, this);
       }else if(this.GAId !== null){
-        window['ga-disable-'+this.GAId] = temp_stage;
+        window['ga-disable-'+this.GAId] = true;
       }
     }else if(ga_list === Object(ga_list)){
       Object.keys(ga_list).map(function(gid){
         window['ga-disable-'+gid] = ga_list[gid]?true:false;
       });
+    }else{
+      throw("Invalid GA profile list");
+    }
+  }
+
+  resetGAFlags(){
+    if(Array.isArray(this.GAId)){
+      this.GAId.map(function(gid){
+        window['ga-disable-'+gid] = false;
+      }, this);
+    }else if(this.GAId !== null){
+      window['ga-disable-'+this.GAId] = false;
     }
   }
 }

--- a/src/trackerClient.js
+++ b/src/trackerClient.js
@@ -173,4 +173,21 @@ class trackerClient{
       throw("Invalid GA / Piwik event");
     }
   }
+
+  disableGA(ga_list = null){
+    if(ga_list === null || ga_list === false || ga_list === true){
+      var temp_stage = ga_list?ga_list:false;
+      if(Array.isArray(this.GAId)){
+        this.GAId.map(function(gid){
+          window['ga-disable-'+gid] = temp_stage;
+        }, this);
+      }else if(this.GAId !== null){
+        window['ga-disable-'+this.GAId] = temp_stage;
+      }
+    }else if(ga_list === Object(ga_list)){
+      Object.keys(ga_list).map(function(gid){
+        window['ga-disable-'+gid] = ga_list[gid]?true:false;
+      });
+    }
+  }
 }


### PR DESCRIPTION
Call `myTracker.disableGA` before and after the target events / PV, which can disable sending it to specific GA profile.